### PR TITLE
Add xray_trace_id option to provide the X-Amzn-Trace-Id header

### DIFF
--- a/lib/ex_aws/lambda.ex
+++ b/lib/ex_aws/lambda.ex
@@ -162,7 +162,7 @@ defmodule ExAws.Lambda do
   def invoke(function_name, payload, client_context, opts \\ []) do
     {qualifier, opts} = Map.pop(Enum.into(opts, %{}), :qualifier)
 
-    headers = [invocation_type: "X-Amz-Invocation-Type", log_type: "X-Amz-Log-Type"]
+    headers = [invocation_type: "X-Amz-Invocation-Type", log_type: "X-Amz-Log-Type", xray_trace_id: "X-Amzn-Trace-Id"]
     |> Enum.reduce([], fn({opt, header}, headers) ->
       case Map.fetch(opts, opt) do
         :error       -> headers

--- a/test/lib/lambda_test.exs
+++ b/test/lib/lambda_test.exs
@@ -2,13 +2,46 @@ defmodule ExAws.LambdaTest do
   use ExUnit.Case, async: true
 
   test "#list_functions" do
-    assert {:ok, %{"Functions" => _}} = ExAws.Lambda.list_functions |> ExAws.request
+    assert %ExAws.Operation.JSON{
+      before_request: nil,
+      data: %{},
+      headers: [{"content-type", "application/json"}],
+      http_method: :get,
+      params: %{},
+      parser: _,
+      path: "/2015-03-31/functions/?",
+      service: :lambda,
+      stream_builder: nil
+    } = ExAws.Lambda.list_functions
   end
 
-  test "callback on invoke works for encoding context" do
-    op = ExAws.Lambda.invoke("yo", "dawg", "asdfasdf")
-    assert {"X-Amz-Client-Context", header} = op.before_request.(op, %{json_codec: Poison}).headers |> List.keyfind("X-Amz-Client-Context", 0)
-    assert header == "ImFzZGZhc2RmIg=="
-  end
+  describe "Lambda.invoke" do
+    test "callback on invoke works for encoding context before request" do
+      op = ExAws.Lambda.invoke("func-name", "func-payload", "asdfasdf")
+      before_request = op.before_request.(op, %{json_codec: Poison})
 
+      assert {"X-Amz-Client-Context", "ImFzZGZhc2RmIg=="} in before_request.headers
+    end
+
+    test "xray_trace_id option adds the X-Amzn-Trace-Id header" do
+      op = ExAws.Lambda.invoke("func-name", "func-payload", %{}, xray_trace_id: "1-aaaaa-bbbbbbbbb")
+      assert {"X-Amzn-Trace-Id", "1-aaaaa-bbbbbbbbb"} in op.headers
+    end
+
+    test "builds ExAws operation" do
+      assert %ExAws.Operation.JSON{
+        before_request: _,
+        data: "func-payload",
+        headers: [
+          {"content-type", "application/json"}
+        ],
+        http_method: :post,
+        params: %{},
+        parser: _,
+        path: "/2015-03-31/functions/func-name/invocations?",
+        service: :lambda,
+        stream_builder: nil
+      } = ExAws.Lambda.invoke("func-name", "func-payload", %{})
+    end
+  end
 end


### PR DESCRIPTION
This PR aims to enable the ability to invoke a lambda and pass through the trace id value required for AWS Xray.



https://aws.amazon.com/xray/