### PR TITLE
Allow containers in create_function

### DIFF
--- a/lib/ex_aws/lambda.ex
+++ b/lib/ex_aws/lambda.ex
@@ -124,7 +124,7 @@ defmodule ExAws.Lambda do
   def create_function(function_name, handler, zipfile_or_container_uri, opts \\ []) do
     code =
       if opts[:package_type] == "Image" do
-        %{"Code" => %{"ImageURI" => zipfile_or_container_uri}}
+        %{"Code" => %{"ImageUri" => zipfile_or_container_uri}}
       else
         %{"Code" => %{"ZipFile" => zipfile_or_container_uri}, "Handler" => handler}
       end

--- a/lib/ex_aws/lambda.ex
+++ b/lib/ex_aws/lambda.ex
@@ -105,27 +105,37 @@ defmodule ExAws.Lambda do
   Create a function.
 
   Runtime defaults to nodejs, as that is the only one available.
+
+  If options contains `package_type`, then if that is "Image" the function creates
+  a container function; else it will create a zipfile-based function. For a container,
+  the `handler` argument will be ignored.
   """
   @spec create_function(
           function_name :: binary,
           handler :: binary,
-          zipfile :: binary
+          zipfile_or_container_uri :: binary
         ) :: ExAws.Operation.JSON.t()
   @spec create_function(
           function_name :: binary,
           handler :: binary,
-          zipfile :: binary,
+          zipfile_or_container_uri :: binary,
           opts :: create_function_opts
         ) :: ExAws.Operation.JSON.t()
-  def create_function(function_name, handler, zipfile, opts \\ []) do
+  def create_function(function_name, handler, zipfile_or_container_uri, opts \\ []) do
+    code =
+      if opts[:package_type] == "Image" do
+        %{"Code" => %{"ImageURI" => zipfile_or_container_uri}}
+      else
+        %{"Code" => %{"ZipFile" => zipfile_or_container_uri}, "Handler" => handler}
+      end
+
     data =
       opts
       |> normalize_opts
       |> Map.merge(%{
         "FunctionName" => function_name,
-        "Handler" => handler,
-        "Code" => %{"ZipFile" => zipfile}
       })
+      |> Map.merge(code)
 
     request(:create_function, data, "/2015-03-31/functions")
   end

--- a/lib/ex_aws/lambda.ex
+++ b/lib/ex_aws/lambda.ex
@@ -133,7 +133,7 @@ defmodule ExAws.Lambda do
       opts
       |> normalize_opts
       |> Map.merge(%{
-        "FunctionName" => function_name,
+        "FunctionName" => function_name
       })
       |> Map.merge(code)
 


### PR DESCRIPTION
We need to create functions on-the-fly from containers; this patch attempts to keep the API for the function the same for backwards compatibility but now allows to configure containers as well. 